### PR TITLE
Misc. additions and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,11 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/novacrazy/rust-tribool"
 
+[features]
+serde-impl = ["serde"]
+
 [dependencies]
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+serde_json = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tribool"
 version = "0.2.0"
 authors = ["Aaron Trent <novacrazy@gmail.com>"]
+edition = "2021"
 description = "Tribool - Three-valued logic"
 documentation = "https://docs.rs/tribool/"
 include = ["src/**/*", "Cargo.toml"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,14 @@ impl FromStr for Tribool {
 
 impl Tribool {
     /// Returns `true` only if `self` is `True`
+    ///
+    /// # Example
+    /// ```
+    /// # use tribool::Tribool;
+    /// # fn main() {
+    /// assert!(Tribool::True.is_true())
+    /// # }
+    /// ```
     #[inline]
     pub fn is_true(self) -> bool {
         match self {
@@ -59,6 +67,14 @@ impl Tribool {
     }
 
     /// Returns `true` only if `self` is `False`
+    ///
+    /// # Example
+    /// ```
+    /// # use tribool::Tribool;
+    /// # fn main() {
+    /// assert!(Tribool::False.is_false())
+    /// # }
+    /// ```
     #[inline]
     pub fn is_false(self) -> bool {
         match self {
@@ -68,6 +84,14 @@ impl Tribool {
     }
 
     /// Returns `true` only if `self` is `Indeterminate`
+    ///
+    /// # Example
+    /// ```
+    /// # use tribool::Tribool;
+    /// # fn main() {
+    /// assert!(Tribool::Indeterminate.is_indeterminate())
+    /// # }
+    /// ```
     #[inline]
     pub fn is_indeterminate(self) -> bool {
         match self {
@@ -78,6 +102,16 @@ impl Tribool {
 
     /// Checks for equality of two `Tribool`s,
     /// returning `Indeterminate` if either are indeterminate.
+    ///
+    /// # Example
+    /// ```
+    /// # use tribool::Tribool;
+    /// # fn main() {
+    /// assert!(Tribool::True.equals(Tribool::True).is_true());
+    /// assert!(Tribool::True.equals(Tribool::False).is_false());
+    /// assert!(Tribool::Indeterminate.equals(Tribool::False).is_indeterminate())
+    /// # }
+    /// ```
     #[inline]
     pub fn equals(self, rhs: Tribool) -> Tribool {
         match (self, rhs) {
@@ -89,6 +123,16 @@ impl Tribool {
 
     /// Checks for inequality of two `Tribool`s,
     /// returning `Indeterminate` if either are indeterminate.
+    ///
+    /// # Example
+    /// ```
+    /// # use tribool::Tribool;
+    /// # fn main() {
+    /// assert!(Tribool::True.not_equals(Tribool::True).is_false());
+    /// assert!(Tribool::True.not_equals(Tribool::False).is_true());
+    /// assert!(Tribool::Indeterminate.not_equals(Tribool::False).is_indeterminate())
+    /// # }
+    /// ```
     #[inline]
     pub fn not_equals(self, rhs: Tribool) -> Tribool {
         match (self, rhs) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,12 @@
 //! For more information and the full truth tables of this implementation, see
 //! [the Wikipedia page](https://en.wikipedia.org/wiki/Three-valued_logic)
 
-use std::ops::{Not, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
-use std::str::FromStr;
+#[cfg(feature = "serde-impl")]
+mod serde;
+
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
+use std::str::FromStr;
 
 /// Three-state Boolean logic
 #[derive(Debug, Clone, Copy, Hash)]
@@ -490,5 +493,25 @@ mod test {
         assert!(True.lukasiewicz_implication(False).is_false());
         assert!(Indeterminate.lukasiewicz_implication(False).is_indeterminate());
         assert!(False.lukasiewicz_implication(False).is_true());
+    }
+
+    #[test]
+    fn serde() {
+        let res_false = serde_json::to_string_pretty(&Tribool::False)
+            .expect("serde Serialize impl for False failed");
+        let res_true = serde_json::to_string_pretty(&Tribool::True)
+            .expect("serde Serialize impl for True failed");
+        let res_none = serde_json::to_string_pretty(&Tribool::Indeterminate)
+            .expect("serde Serialize impl for Indeterminate failed");
+
+        assert!(serde_json::from_str::<Tribool>(&res_false)
+            .expect("serde Deserialize impl for False failed")
+            .is_false());
+        assert!(serde_json::from_str::<Tribool>(&res_true)
+            .expect("serde Deserialize impl for True failed")
+            .is_true());
+        assert!(serde_json::from_str::<Tribool>(&res_none)
+            .expect("serde Deserialize impl for Indeterminate failed")
+            .is_indeterminate())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,13 @@ pub enum Tribool {
     Indeterminate,
 }
 
-pub use Tribool::{True, False, Indeterminate};
+pub use Tribool::{False, Indeterminate, True};
 
 impl Default for Tribool {
     #[inline]
-    fn default() -> Tribool { False }
+    fn default() -> Tribool {
+        False
+    }
 }
 
 impl FromStr for Tribool {
@@ -40,7 +42,7 @@ impl FromStr for Tribool {
     fn from_str(s: &str) -> Result<Tribool, ()> {
         Ok(match bool::from_str(s) {
             Ok(b) => Tribool::from(b),
-            _ => Indeterminate
+            _ => Indeterminate,
         })
     }
 }
@@ -76,7 +78,7 @@ impl Tribool {
         match (self, rhs) {
             (False, False) | (True, True) => True,
             (False, True) | (True, False) => False,
-            _ => Indeterminate
+            _ => Indeterminate,
         }
     }
 
@@ -86,7 +88,7 @@ impl Tribool {
         match (self, rhs) {
             (False, False) | (True, True) => False,
             (False, True) | (True, False) => True,
-            _ => Indeterminate
+            _ => Indeterminate,
         }
     }
 
@@ -116,11 +118,14 @@ impl Tribool {
 
 impl Display for Tribool {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        Display::fmt(match *self {
-            True => "True",
-            False => "False",
-            Indeterminate => "Indeterminate",
-        }, f)
+        Display::fmt(
+            match *self {
+                True => "True",
+                False => "False",
+                Indeterminate => "Indeterminate",
+            },
+            f,
+        )
     }
 }
 
@@ -156,7 +161,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
             (Indeterminate, _) | (_, Indeterminate) => None,
             (True, False) => Some(Ordering::Greater),
             (False, True) => Some(Ordering::Less),
-            (True, True) | (False, False) => Some(Ordering::Equal)
+            (True, True) | (False, False) => Some(Ordering::Equal),
         }
     }
 
@@ -208,7 +213,7 @@ impl<B: Into<Tribool>> BitAnd<B> for Tribool {
         match (self, rhs.into()) {
             (True, True) => True,
             (False, _) | (_, False) => False,
-            _ => Indeterminate
+            _ => Indeterminate,
         }
     }
 }
@@ -220,7 +225,7 @@ impl<B: Into<Tribool>> BitOr<B> for Tribool {
         match (self, rhs.into()) {
             (False, False) => False,
             (True, _) | (_, True) => True,
-            _ => Indeterminate
+            _ => Indeterminate,
         }
     }
 }
@@ -258,7 +263,7 @@ macro_rules! impl_binary_op {
                 *self = rhs.$f(*self).is_true()
             }
         }
-    }
+    };
 }
 
 impl_binary_op!(BitAnd => bitand, BitAndAssign => bitand_assign);
@@ -268,7 +273,11 @@ impl_binary_op!(BitXor => bitxor, BitXorAssign => bitxor_assign);
 impl From<bool> for Tribool {
     #[inline]
     fn from(value: bool) -> Tribool {
-        if value { True } else { False }
+        if value {
+            True
+        } else {
+            False
+        }
     }
 }
 
@@ -291,7 +300,7 @@ macro_rules! forward_ref_unop {
                 $imp::$method(*self)
             }
         }
-    }
+    };
 }
 
 // implements binary operators "&T op U", "T op &U", "&T op &U"
@@ -324,7 +333,7 @@ macro_rules! forward_ref_binop {
                 $imp::$method(*self, *other)
             }
         }
-    }
+    };
 }
 
 forward_ref_unop!(impl Not, not for Tribool);
@@ -347,10 +356,10 @@ mod test {
 
     #[test]
     fn equality() {
-        assert!(True == True);
-        assert!(True != False);
-        assert!(False != True);
-        assert!(False == False);
+        assert_eq!(True, True);
+        assert_ne!(True, False);
+        assert_ne!(False, True);
+        assert_eq!(False, False);
 
         assert!(!(Indeterminate == True));
         assert!(!(Indeterminate == False));
@@ -362,10 +371,10 @@ mod test {
 
     #[test]
     fn bool_equality() {
-        assert!(True == true);
-        assert!(False == false);
-        assert!(True != false);
-        assert!(False != true);
+        assert_eq!(True, true);
+        assert_eq!(False, false);
+        assert_ne!(True, false);
+        assert_ne!(False, true);
         assert!(!(Indeterminate != true));
         assert!(!(Indeterminate != false));
     }
@@ -466,13 +475,15 @@ mod test {
     }
 
     #[test]
-    fn kleen() {
+    fn kleene() {
         assert!(True.kleene_implication(True).is_true());
         assert!(Indeterminate.kleene_implication(True).is_true());
         assert!(False.kleene_implication(True).is_true());
 
         assert!(True.kleene_implication(Indeterminate).is_indeterminate());
-        assert!(Indeterminate.kleene_implication(Indeterminate).is_indeterminate());
+        assert!(Indeterminate
+            .kleene_implication(Indeterminate)
+            .is_indeterminate());
         assert!(False.kleene_implication(Indeterminate).is_true());
 
         assert!(True.kleene_implication(False).is_false());
@@ -486,12 +497,18 @@ mod test {
         assert!(Indeterminate.lukasiewicz_implication(True).is_true());
         assert!(False.lukasiewicz_implication(True).is_true());
 
-        assert!(True.lukasiewicz_implication(Indeterminate).is_indeterminate());
-        assert!(Indeterminate.lukasiewicz_implication(Indeterminate).is_true());
+        assert!(True
+            .lukasiewicz_implication(Indeterminate)
+            .is_indeterminate());
+        assert!(Indeterminate
+            .lukasiewicz_implication(Indeterminate)
+            .is_true());
         assert!(False.lukasiewicz_implication(Indeterminate).is_true());
 
         assert!(True.lukasiewicz_implication(False).is_false());
-        assert!(Indeterminate.lukasiewicz_implication(False).is_indeterminate());
+        assert!(Indeterminate
+            .lukasiewicz_implication(False)
+            .is_indeterminate());
         assert!(False.lukasiewicz_implication(False).is_true());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ impl Default for Tribool {
 impl FromStr for Tribool {
     type Err = ();
 
+    #[inline]
     fn from_str(s: &str) -> Result<Tribool, ()> {
         Ok(match bool::from_str(s) {
             Ok(b) => Tribool::from(b),
@@ -49,6 +50,7 @@ impl FromStr for Tribool {
 
 impl Tribool {
     /// Returns `true` only if `self` is `True`
+    #[inline]
     pub fn is_true(self) -> bool {
         match self {
             True => true,
@@ -57,6 +59,7 @@ impl Tribool {
     }
 
     /// Returns `true` only if `self` is `False`
+    #[inline]
     pub fn is_false(self) -> bool {
         match self {
             False => true,
@@ -65,6 +68,7 @@ impl Tribool {
     }
 
     /// Returns `true` only if `self` is `Indeterminate`
+    #[inline]
     pub fn is_indeterminate(self) -> bool {
         match self {
             Indeterminate => true,
@@ -74,6 +78,7 @@ impl Tribool {
 
     /// Checks for equality of two `Tribool`s,
     /// returning `Indeterminate` if either are indeterminate.
+    #[inline]
     pub fn equals(self, rhs: Tribool) -> Tribool {
         match (self, rhs) {
             (False, False) | (True, True) => True,
@@ -84,6 +89,7 @@ impl Tribool {
 
     /// Checks for inequality of two `Tribool`s,
     /// returning `Indeterminate` if either are indeterminate.
+    #[inline]
     pub fn not_equals(self, rhs: Tribool) -> Tribool {
         match (self, rhs) {
             (False, False) | (True, True) => False,
@@ -106,6 +112,7 @@ impl Tribool {
     /// but differs in its definition of implication in that "unknown implies unknown" is true.
     ///
     /// For more information, see [the Wikipedia page and the section on Łukasiewicz Logic](https://en.wikipedia.org/wiki/Three-valued_logic#.C5.81ukasiewicz_logic)
+    #[inline]
     pub fn lukasiewicz_implication(self, b: Tribool) -> Tribool {
         match (self, b) {
             (True, Indeterminate) | (Indeterminate, False) => Indeterminate,
@@ -117,6 +124,7 @@ impl Tribool {
 }
 
 impl Display for Tribool {
+    #[inline]
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         Display::fmt(
             match *self {
@@ -156,6 +164,7 @@ impl PartialEq<Tribool> for bool {
 use std::cmp::Ordering;
 
 impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
+    #[inline]
     fn partial_cmp(&self, rhs: &B) -> Option<Ordering> {
         match (*self, (*rhs).into()) {
             (Indeterminate, _) | (_, Indeterminate) => None,
@@ -165,6 +174,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
         }
     }
 
+    #[inline]
     fn lt(&self, rhs: &B) -> bool {
         match (*self, (*rhs).into()) {
             (False, True) => true,
@@ -172,6 +182,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
         }
     }
 
+    #[inline]
     fn le(&self, rhs: &B) -> bool {
         match (*self, (*rhs).into()) {
             (True, True) | (False, False) | (False, True) => true,
@@ -179,6 +190,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
         }
     }
 
+    #[inline]
     fn gt(&self, rhs: &B) -> bool {
         match (*self, (*rhs).into()) {
             (True, False) => true,
@@ -186,6 +198,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
         }
     }
 
+    #[inline]
     fn ge(&self, rhs: &B) -> bool {
         match (*self, (*rhs).into()) {
             (True, True) | (False, False) | (True, False) => true,
@@ -197,6 +210,7 @@ impl<B: Into<Tribool> + Copy> PartialOrd<B> for Tribool {
 impl Not for Tribool {
     type Output = Tribool;
 
+    #[inline]
     fn not(self) -> Tribool {
         match self {
             True => False,
@@ -209,6 +223,7 @@ impl Not for Tribool {
 impl<B: Into<Tribool>> BitAnd<B> for Tribool {
     type Output = Tribool;
 
+    #[inline]
     fn bitand(self, rhs: B) -> Tribool {
         match (self, rhs.into()) {
             (True, True) => True,
@@ -221,6 +236,7 @@ impl<B: Into<Tribool>> BitAnd<B> for Tribool {
 impl<B: Into<Tribool>> BitOr<B> for Tribool {
     type Output = Tribool;
 
+    #[inline]
     fn bitor(self, rhs: B) -> Tribool {
         match (self, rhs.into()) {
             (False, False) => False,
@@ -233,6 +249,7 @@ impl<B: Into<Tribool>> BitOr<B> for Tribool {
 impl<B: Into<Tribool>> BitXor<B> for Tribool {
     type Output = Tribool;
 
+    #[inline]
     fn bitxor(self, rhs: B) -> Tribool {
         let rhs = rhs.into();
         (self | rhs) & !(self & rhs)

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,73 @@
+use crate::Tribool::{self, *};
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::Formatter;
+
+// ************************ //
+// Serialize implementation //
+// ************************ //
+impl Serialize for Tribool {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            True | False => serializer.serialize_bool(self.is_true()),
+            Indeterminate => serializer.serialize_none(),
+        }
+    }
+}
+
+// ******************************* //
+// Boolean visitor for Deserialize //
+// ******************************* //
+struct NullBoolVisitor;
+impl<'de> Visitor<'de> for NullBoolVisitor {
+    type Value = Tribool;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("a nullable boolean value")
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Tribool::from(v))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Tribool::Indeterminate)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bool(Self)
+    }
+}
+
+// ************************** //
+// Deserialize implementation //
+// ************************** //
+impl<'de> Deserialize<'de> for Tribool {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_option(NullBoolVisitor)
+    }
+
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let val = deserializer.deserialize_option(NullBoolVisitor)?;
+        *place = val;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a optional implementation for Serde, gated behind the `serde-impl` feature flag. It also bumps the Rust edition to 2021, formats all files, inlines all functions, and adds some documentation examples.